### PR TITLE
Force utf-8 encoding on request headers

### DIFF
--- a/lib/elastic_apm/context_builder.rb
+++ b/lib/elastic_apm/context_builder.rb
@@ -76,9 +76,9 @@ module ElasticAPM
         next unless key == key.upcase
 
         if key.start_with?('HTTP_')
-          http[camel_key(key)] = value
+          http[camel_key(key)] = value.dup.force_encoding('utf-8')
         else
-          env[key] = value
+          env[key] = value.dup.force_encoding('utf-8')
         end
       end
     end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -143,6 +143,18 @@ if enabled
       end
     end
 
+    context 'utf-8 headers' do
+      let(:header_value) { (+'Malmö').force_encoding('ASCII-8BIT') }
+
+      it 'does not crash' do
+        get '/', {}, { 'HTTP_GEOIP_CITY' => header_value }
+
+        expect {
+          EventCollector.wait_for transactions: 1, spans: 2
+        }.not_to raise_error
+      end
+    end
+
     describe 'transactions' do
       context 'when a simple request is made' do
         it 'spans action and posts it' do


### PR DESCRIPTION
## What does this pull request do?

It will allow sending UTF-8 encoded headers to ElasticAPM

## Why is it important?

Currently, we get some amount (approx. 6300 for the past hour) of:

```
[ElasticAPM] Failed converting event to JSON: <ElasticAPM::Transaction id:062db768ee2b900e name:"PusherController#auth" type:"request">
`````
errors. They are caused by Elastic APM agent not being able to serialize request with UTF-8 encoded headers (which is not allowed by RFC btw.) So we don't get all the information in APM and also pollute logs with error messages.